### PR TITLE
fix: do not rerun actions on merge

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -2,8 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: test
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@ default_language_version:
 repos:
 - hooks:
   - args:
+    - --branch=main
+    id: no-commit-to-branch
+  repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+- hooks:
+  - args:
     - --fix
     id: ruff
     types:


### PR DESCRIPTION
Pushing to main is disabled anyway, so do not rerun actions after merge.